### PR TITLE
Fix missing variant lookup method

### DIFF
--- a/wizards/import_product_variant.py
+++ b/wizards/import_product_variant.py
@@ -1050,6 +1050,10 @@ class ImportVariant(models.TransientModel):
         
         return variant
 
+    def _find_existing_variant_by_default_code(self, product_tmpl, values):
+        """Compatibility wrapper to locate variants by internal reference."""
+        return self._find_variant_by_default_code(product_tmpl, values)
+
     def _get_selection_key(self, field_name, value):
         """Get selection key from field selection."""
         field_selection = dict(self.env['product.template']._fields[field_name].selection)


### PR DESCRIPTION
## Summary
- add `_find_existing_variant_by_default_code` for compatibility

## Testing
- `python -m py_compile wizards/import_product_variant.py`

------
https://chatgpt.com/codex/tasks/task_e_6882599f0100832daeda74e91725d522